### PR TITLE
Attempt to make string literals higher priority

### DIFF
--- a/packages/klipper-cfg/src/lib/repository/index.ts
+++ b/packages/klipper-cfg/src/lib/repository/index.ts
@@ -16,6 +16,6 @@ export default {
 	literal,
 	nullLiteral,
 	numericLiteral,
-	stringLiteral,
 	punctuation,
+	stringLiteral,
 };


### PR DESCRIPTION
I'm not entirely sure I understand the TextMate grammer. I think this document tells me that lower-down is higher priority. https://macromates.com/manual/en/scope_selectors

It seems like string literals should have much higher priority, but I see that you want to be able to put things like variable names inside of string literals. What I would do is make a recursive grammar where python and klipper glyphs can be injected into string literals, rather than letting any identifier occupy a string litera.

Anyways, I'm happy to test this out, but I don't know how TextMate is built or tested. If you've got the bandwidth to test and merge that would be great. Otherwise, can you help me figure out how to test this?