### PR TITLE
Bugfix: Strings delimited by escaped quotes (`\"`) in Jinja templates begin but never end

### DIFF
--- a/packages/klipper-cfg/src/lib/repository/literals.ts
+++ b/packages/klipper-cfg/src/lib/repository/literals.ts
@@ -15,7 +15,7 @@ export const stringLiteral: TMGrammarScope = {
 	patterns: [
 		{
 			name: "string.klipper-cfg",
-			begin: /(?<!\\)(")|\\\\(")/,
+			begin: /(?<!\\)(")/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.string.begin.klipper-cfg" },
 			},
@@ -27,7 +27,7 @@ export const stringLiteral: TMGrammarScope = {
 		},
 		{
 			name: "string.klipper-cfg",
-			begin: /(?<!\\)(')|\\\\(')/,
+			begin: /(?<!\\)(')/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.string.begin.klipper-cfg" },
 			},

--- a/packages/klipper-cfg/src/lib/repository/literals.ts
+++ b/packages/klipper-cfg/src/lib/repository/literals.ts
@@ -15,7 +15,7 @@ export const stringLiteral: TMGrammarScope = {
 	patterns: [
 		{
 			name: "string.klipper-cfg",
-			begin: /"/,
+			begin: /(?<!\\)(")|\\\\(")/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.string.begin.klipper-cfg" },
 			},
@@ -27,7 +27,7 @@ export const stringLiteral: TMGrammarScope = {
 		},
 		{
 			name: "string.klipper-cfg",
-			begin: /'/,
+			begin: /(?<!\\)(')|\\\\(')/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.string.begin.klipper-cfg" },
 			},

--- a/packages/klipper-gcode/src/lib/repository/literals.ts
+++ b/packages/klipper-gcode/src/lib/repository/literals.ts
@@ -7,7 +7,7 @@ export const boolLiteral: TMGrammarScope = {
 
 export const stringLiteral: TMGrammarScope = {
 	name: "string.klipper-gcode",
-	begin: /(?<!\\)(")|\\\\(")/,
+	begin: /(?<!\\)(")/,
 	beginCaptures: {
 		0: { name: "punctuation.definition.string.begin.klipper-gcode" },
 	},

--- a/packages/klipper-gcode/src/lib/repository/literals.ts
+++ b/packages/klipper-gcode/src/lib/repository/literals.ts
@@ -7,7 +7,7 @@ export const boolLiteral: TMGrammarScope = {
 
 export const stringLiteral: TMGrammarScope = {
 	name: "string.klipper-gcode",
-	begin: /"/,
+	begin: /(?<!\\)(")|\\\\(")/,
 	beginCaptures: {
 		0: { name: "punctuation.definition.string.begin.klipper-gcode" },
 	},

--- a/packages/klipper-script/src/lib/repository/literals.ts
+++ b/packages/klipper-script/src/lib/repository/literals.ts
@@ -14,7 +14,7 @@ export const stringLiteral: TMGrammarScope = {
 	patterns: [
 		{
 			name: "string.klipper-script",
-			begin: /(?<!\\)(')|\\\\(')/,
+			begin: /(?<!\\)(')/,
 			beginCaptures: {
 				1: { name: "punctuation.definition.string.begin.klipper-script" },
 			},
@@ -26,7 +26,7 @@ export const stringLiteral: TMGrammarScope = {
 		},
 		{
 			name: "string.klipper-script",
-			begin: /(?<!\\)(")|\\\\(")/,
+			begin: /(?<!\\)(")/,
 			beginCaptures: {
 				1: { name: "punctuation.definition.string.begin.klipper-script" },
 			},

--- a/packages/klipper-script/src/lib/repository/literals.ts
+++ b/packages/klipper-script/src/lib/repository/literals.ts
@@ -11,16 +11,32 @@ export const nullLiteral: TMGrammarScope = {
 };
 
 export const stringLiteral: TMGrammarScope = {
-	name: "string.klipper-script",
-	begin: /(["'])/,
-	beginCaptures: {
-		1: { name: "punctuation.definition.string.begin.klipper-script" },
-	},
-	end: /(?<!\\)(\1)|\\\\(\1)/,
-	endCaptures: {
-		1: { name: "punctuation.definition.string.end.klipper-script" },
-		2: { name: "punctuation.definition.string.end.klipper-script" },
-	},
+	patterns: [
+		{
+			name: "string.klipper-script",
+			begin: /(?<!\\)(')|\\\\(')/,
+			beginCaptures: {
+				1: { name: "punctuation.definition.string.begin.klipper-script" },
+			},
+			end: /(?<!\\)(')|\\\\(')/,
+			endCaptures: {
+				1: { name: "punctuation.definition.string.end.klipper-script" },
+				2: { name: "punctuation.definition.string.end.klipper-script" },
+			},
+		},
+		{
+			name: "string.klipper-script",
+			begin: /(?<!\\)(")|\\\\(")/,
+			beginCaptures: {
+				1: { name: "punctuation.definition.string.begin.klipper-script" },
+			},
+			end: /(?<!\\)(")|\\\\(")/,
+			endCaptures: {
+				1: { name: "punctuation.definition.string.end.klipper-script" },
+				2: { name: "punctuation.definition.string.end.klipper-script" },
+			},
+		},
+	]
 };
 
 export const numericLiteral: TMGrammarScope = {


### PR DESCRIPTION
stringLiterals in all 3 packages were looking for just an open quote, not checking for it being escaped. This PR uses the end condition regex for the begin conditions as well.

Fixes #9 