### PR TITLE
differentiation for `description:` blocks, adding missed filters and jinja macros

### DIFF
--- a/packages/klipper-cfg/src/lib/repository/identifier.ts
+++ b/packages/klipper-cfg/src/lib/repository/identifier.ts
@@ -63,6 +63,19 @@ export const identifier: TMGrammarScope = {
 			],
 		},
 		{
+			name: "meta.property-block.description.klipper-cfg",
+			begin: /^(description)(:)/,
+			beginCaptures: {
+				1: { name: "variable.property.klipper-cfg" },
+				2: { name: "punctuation.separator.key-value.klipper-cfg" },
+			},
+			end: /(?=^\S)/,
+			contentName: "string.unquoted.description.klipper-cfg",
+			patterns: [
+				{ include: "#comment" },
+			],
+		},
+		{
 			name: "meta.property-block.entry.klipper-cfg",
 			begin: regex`/^(${IDENT})(:)/`,
 			beginCaptures: {

--- a/packages/klipper-cfg/src/lib/repository/identifier.ts
+++ b/packages/klipper-cfg/src/lib/repository/identifier.ts
@@ -76,6 +76,20 @@ export const identifier: TMGrammarScope = {
 			],
 		},
 		{
+			name: "meta.property-block.variable.klipper-cfg",
+			begin: regex`/^(variable_${IDENT})(:)/`,
+			beginCaptures: {
+				1: { name: "variable.property.klipper-cfg" },
+				2: { name: "punctuation.separator.key-value.klipper-cfg" },
+			},
+			end: /(?=^\S)/,
+			patterns: [
+				{ include: "#comment" },
+				{ include: "#literal" },
+				{ include: "#punctuation" },
+			],
+		},
+		{
 			name: "meta.property-block.entry.klipper-cfg",
 			begin: regex`/^(${IDENT})(:)/`,
 			beginCaptures: {

--- a/packages/klipper-cfg/src/lib/repository/literals.ts
+++ b/packages/klipper-cfg/src/lib/repository/literals.ts
@@ -1,9 +1,8 @@
-import { regex, TMGrammarScope } from "@vscode-devkit/grammar";
-import { IDENT } from "../common";
+import { TMGrammarScope } from "@vscode-devkit/grammar";
 
 export const boolLiteral: TMGrammarScope = {
 	name: "constant.language.boolean.klipper-cfg",
-	match: /\b[Tt]rue|[Ff]alse\b/,
+	match: /\b(?:[Tt]rue|[Ff]alse)\b/,
 };
 
 export const nullLiteral: TMGrammarScope = {
@@ -39,7 +38,7 @@ export const stringLiteral: TMGrammarScope = {
 		},
 		{
 			name: "string.path.klipper-cfg",
-			match: regex`/(\/${IDENT})+/`,
+			match: /\/[^\s#;]+/,
 		}
 	],
 };

--- a/packages/klipper-cfg/src/lib/repository/template.ts
+++ b/packages/klipper-cfg/src/lib/repository/template.ts
@@ -3,12 +3,31 @@ import { TMGrammarScope } from "@vscode-devkit/grammar";
 export const template: TMGrammarScope = {
 	patterns: [
 		{
+			name: "meta.jinja2.block-set.klipper-cfg",
+			begin: /(\{%-?)(\s*)(set)\b((?:(?!-?%\}|=).)*)(-?%\})/,
+			beginCaptures: {
+				1: { name: "punctuation.definition.template-expression.begin.klipper-cfg" },
+				3: { name: "storage.type.set.klipper-script" },
+				5: { name: "punctuation.definition.template-expression.end.klipper-cfg" },
+			},
+			end: /(\{%-?)(\s*)(endset)\b(\s*)(-?%\})/,
+			endCaptures: {
+				1: { name: "punctuation.definition.template-expression.begin.klipper-cfg" },
+				3: { name: "storage.type.endset.klipper-script" },
+				5: { name: "punctuation.definition.template-expression.end.klipper-cfg" },
+			},
+			contentName: "string.unquoted.block-set.klipper-cfg",
+			patterns: [
+				{ include: "#template" },
+			],
+		},
+		{
 			name: "meta.jinja2.conditional.klipper-cfg",
-			begin: /\{%/,
+			begin: /\{%-?/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.template-expression.begin.klipper-cfg" },
 			},
-			end: /%\}/,
+			end: /-?%\}/,
 			endCaptures: {
 				0: { name: "punctuation.definition.template-expression.end.klipper-cfg" },
 			},
@@ -19,11 +38,11 @@ export const template: TMGrammarScope = {
 		},
 		{
 			name: "meta.jinja2.expression.klipper-cfg",
-			begin: /\{/,
+			begin: /\{-?/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.template-expression.begin.klipper-cfg" },
 			},
-			end: /\}/,
+			end: /-?\}/,
 			endCaptures: {
 				0: { name: "punctuation.definition.template-expression.end.klipper-cfg" },
 			},

--- a/packages/klipper-gcode/src/lib/repository/template.ts
+++ b/packages/klipper-gcode/src/lib/repository/template.ts
@@ -3,12 +3,31 @@ import { TMGrammarScope } from "@vscode-devkit/grammar";
 export const template: TMGrammarScope = {
 	patterns: [
 		{
+			name: "meta.jinja2.block-set.klipper-gcode",
+			begin: /(\{%-?)(\s*)(set)\b((?:(?!-?%\}|=).)*)(-?%\})/,
+			beginCaptures: {
+				1: { name: "punctuation.definition.template-expression.begin.klipper-gcode" },
+				3: { name: "storage.type.set.klipper-script" },
+				5: { name: "punctuation.definition.template-expression.end.klipper-gcode" },
+			},
+			end: /(\{%-?)(\s*)(endset)\b(\s*)(-?%\})/,
+			endCaptures: {
+				1: { name: "punctuation.definition.template-expression.begin.klipper-gcode" },
+				3: { name: "storage.type.endset.klipper-script" },
+				5: { name: "punctuation.definition.template-expression.end.klipper-gcode" },
+			},
+			contentName: "string.unquoted.block-set.klipper-gcode",
+			patterns: [
+				{ include: "#template" },
+			],
+		},
+		{
 			name: "meta.jinja2.conditional.klipper-gcode",
-			begin: /\{%/,
+			begin: /\{%-?/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.template-expression.begin.klipper-gcode" },
 			},
-			end: /%\}/,
+			end: /-?%\}/,
 			endCaptures: {
 				0: { name: "punctuation.definition.template-expression.end.klipper-gcode" },
 			},
@@ -19,11 +38,11 @@ export const template: TMGrammarScope = {
 		},
 		{
 			name: "meta.jinja2.expression.klipper-gcode",
-			begin: /\{/,
+			begin: /\{-?/,
 			beginCaptures: {
 				0: { name: "punctuation.definition.template-expression.begin.klipper-gcode" },
 			},
-			end: /\}/,
+			end: /-?\}/,
 			endCaptures: {
 				0: { name: "punctuation.definition.template-expression.end.klipper-gcode" },
 			},

--- a/packages/klipper-script/src/lib/repository/identifier.ts
+++ b/packages/klipper-script/src/lib/repository/identifier.ts
@@ -6,7 +6,7 @@ export const identifier: TMGrammarScope = {
 	patterns: [
 		{
 			name: "entity.name.function.filter.klipper-script",
-			match: /\b(abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|first|float|forceescape|format|groupby|indent|int|join|last|length|list|lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr)\b/,
+			match: /\b(abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|first|float|forceescape|format|groupby|indent|int|join|last|length|list|lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|count|d|e|items|trim)\b/,
 		},
 		{
 			match: regex`/\b(${IDENT})\s*(?=\()/`,

--- a/packages/klipper-script/src/lib/repository/identifier.ts
+++ b/packages/klipper-script/src/lib/repository/identifier.ts
@@ -5,10 +5,6 @@ import { IDENT } from "../common";
 export const identifier: TMGrammarScope = {
 	patterns: [
 		{
-			name: "entity.name.function.filter.klipper-script",
-			match: /\b(abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|first|float|forceescape|format|groupby|indent|int|join|last|length|list|lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|count|d|e|items|trim)\b/,
-		},
-		{
 			match: regex`/\b(${IDENT})\s*(?=\()/`,
 			captures: {
 				1: { name: "entity.name.function.klipper-script" },

--- a/packages/klipper-script/src/lib/repository/keyword.ts
+++ b/packages/klipper-script/src/lib/repository/keyword.ts
@@ -1,10 +1,14 @@
 import { TMGrammarScope } from "@vscode-devkit/grammar";
+const JINJA_TESTS =
+	"boolean|callable|defined|divisibleby|escaped|even|false|filter|float|ge|greaterthan|gt|in|integer|iterable|le|lessthan|lower|lt|mapping|ne|none|number|odd|sameas|sequence|string|test|true|undefined|upper|eq|equalto";
+
+const JINJA_SYMBOL_TESTS = "==|!=|>=|<=|>|<";
 
 export const keyword: TMGrammarScope = {
 	patterns: [
 		{
-		name: "keyword.control.definition.$1.klipper-script",
-		match: /\b(macro|endmacro)\b/,
+			name: "keyword.control.definition.$1.klipper-script",
+			match: /\b(macro|endmacro)\b/,
 		},
 		{
 			name: "keyword.control.iteration.$1.klipper-script",
@@ -15,12 +19,44 @@ export const keyword: TMGrammarScope = {
 			match: /\b(if|elif|else|endif)\b/,
 		},
 		{
+			match: /\b(is)\s+(?:(not)\s+)?([Nn]one)\b/,
+			captures: {
+				1: { name: "keyword.operator.wordlike.logical.is.klipper-script" },
+				2: { name: "keyword.operator.wordlike.logical.not.klipper-script" },
+				3: { name: "constant.language.null.klipper-script" },
+			},
+		},
+		{
+			match: /\b(is)\s+(?:(not)\s+)?([Tt]rue|[Ff]alse)\b/,
+			captures: {
+				1: { name: "keyword.operator.wordlike.logical.is.klipper-script" },
+				2: { name: "keyword.operator.wordlike.logical.not.klipper-script" },
+				3: { name: "constant.language.boolean.klipper-script" },
+			},
+		},
+		{
+			match: new RegExp(`\\b(is)\\s+(?:(not)\\s+)?(${JINJA_TESTS})\\b`),
+			captures: {
+				1: { name: "keyword.operator.wordlike.logical.is.klipper-script" },
+				2: { name: "keyword.operator.wordlike.logical.not.klipper-script" },
+				3: { name: "entity.name.function.test.klipper-script" },
+			},
+		},
+		{
+			match: new RegExp(`\\b(is)\\s+(?:(not)\\s+)?(${JINJA_SYMBOL_TESTS})`),
+			captures: {
+				1: { name: "keyword.operator.wordlike.logical.is.klipper-script" },
+				2: { name: "keyword.operator.wordlike.logical.not.klipper-script" },
+				3: { name: "entity.name.function.test.klipper-script" },
+			},
+		},
+		{
 			name: "keyword.operator.wordlike.logical.$1.klipper-script",
-			match: /\b(and|or|not|is)\b/
+			match: /\b(and|or|not|is)\b/,
 		},
 		{
 			name: "storage.type.$1.klipper-script",
-			match: /\b(set)\b/,
+			match: /\b(set|endset)\b/,
 		},
 	],
 };
@@ -38,6 +74,13 @@ export const operator: TMGrammarScope = {
 		{
 			name: "keyword.operator.concatenation.klipper-script",
 			match: /~/,
+		},
+		{
+			match: /(\|)\s*(abs|attr|batch|capitalize|center|default|dictsort|escape|filesizeformat|first|float|forceescape|format|groupby|indent|int|join|last|length|list|lower|map|max|min|pprint|random|reject|rejectattr|replace|reverse|round|safe|select|selectattr|slice|sort|string|striptags|sum|title|tojson|truncate|unique|upper|urlencode|urlize|wordcount|wordwrap|xmlattr|count|d|e|items|trim)\b/,
+			captures: {
+				1: { name: "keyword.operator.pipe.klipper-script" },
+				2: { name: "entity.name.function.filter.klipper-script" },
+			},
 		},
 		{
 			name: "keyword.operator.pipe.klipper-script",

--- a/packages/klipper-script/src/lib/repository/keyword.ts
+++ b/packages/klipper-script/src/lib/repository/keyword.ts
@@ -3,6 +3,10 @@ import { TMGrammarScope } from "@vscode-devkit/grammar";
 export const keyword: TMGrammarScope = {
 	patterns: [
 		{
+		name: "keyword.control.definition.$1.klipper-script",
+		match: /\b(macro|endmacro)\b/,
+		},
+		{
 			name: "keyword.control.iteration.$1.klipper-script",
 			match: /\b(for|in|endfor)\b/,
 		},

--- a/packages/klipper-script/src/lib/repository/literals.ts
+++ b/packages/klipper-script/src/lib/repository/literals.ts
@@ -2,7 +2,7 @@ import { TMGrammarScope } from "@vscode-devkit/grammar";
 
 export const boolLiteral: TMGrammarScope = {
 	name: "constant.language.boolean.klipper-script",
-	match: /\b[Tt]rue|[Ff]alse\b/,
+	match: /\b(?:[Tt]rue|[Ff]alse)\b/,
 };
 
 export const nullLiteral: TMGrammarScope = {


### PR DESCRIPTION
Add support/differentiation for 'description' property block in klipper-cfg and extend keyword patterns in klipper-script